### PR TITLE
Use callback refs instead of findDOMnode

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var React = require('react')
-var ReactDOM = require('react-dom')
 var A11yDialog = require('a11y-dialog')
 
 var Dialog = React.createClass({
@@ -32,7 +31,7 @@ var Dialog = React.createClass({
   },
 
   initDialog: function () {
-    const node = ReactDOM.findDOMNode(this)
+    const node = this.node
     const root = document.querySelector(this.props.rootSelector)
 
     // The dialog element should not live in the application main container but
@@ -55,7 +54,7 @@ var Dialog = React.createClass({
     const titleId = this.props.titleId || (id + '-title')
 
     return (
-      <div id={id} aria-hidden>
+      <div id={id} ref={node => this.node = node} aria-hidden>
         <div tabIndex='-1' onClick={this.close} />
 
         <div role='dialog' aria-labelledby={titleId}>


### PR DESCRIPTION
Greetings,

`findDOMnode` is most likely to be deprecated in future React versions.
See https://github.com/yannickcr/eslint-plugin-react/issues/678 for detailed explanations.

Feel free to do whatever you want with this MR.

;)