### PR TITLE
updates package.json to use the latest release of standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.0",
-    "standard": "^10.0.3"
+    "standard": "^11.0.0"
   },
   "peerDependencies": {
     "prop-types": "^15.6.0",


### PR DESCRIPTION
Hi @HugoGiraudel, here's a small dependency update.

This PR updates the package.json of react-a11y-dialog so that `npm install` will install the latest dependencies.

It only affects the dependency to [standardjs](https://github.com/standard/standard/). Which will be updated to v11.0.1 (all other dependencies are satisfied by the current `package.json`).

Hope that helps keeping your repository more up to date. ;)

Cheers
Eric