### PR TITLE
Allow title prop to be of type PropTypes.element

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install --save react-a11y-dialog
 ---
 
 * **Property name**: `title`
-* **Type**: string
+* **Type**: string | element
 * **Mandatory**: true
 * **Default value**: —
 * **Description**: The title of the dialog, mandatory in the document to provide context to assistive technology. Could be [hidden with CSS](https://hugogiraudel.com/2016/10/13/css-hide-and-seek/) (while remaining accessible).

--- a/dist/index.js
+++ b/dist/index.js
@@ -145,7 +145,7 @@ Dialog.propTypes = {
   // The title of the dialog, mandatory in the document to provide context to
   // assistive technology. Could be hidden (while remaining accessible) with
   // CSS though.
-  title: PropTypes.string.isRequired,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
 
   // A function called when the component has mounted, receiving the instance
   // of A11yDialog so that it can be programmatically accessed later on.

--- a/index.js
+++ b/index.js
@@ -116,7 +116,10 @@ Dialog.propTypes = {
   // The title of the dialog, mandatory in the document to provide context to
   // assistive technology. Could be hidden (while remaining accessible) with
   // CSS though.
-  title: PropTypes.string.isRequired,
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.element
+  ]).isRequired,
 
   // A function called when the component has mounted, receiving the instance
   // of A11yDialog so that it can be programmatically accessed later on.


### PR DESCRIPTION
Hi @HugoGiraudel, here's a small feature request.

This PR updates the allowed type for the `title` prop of react-a11y-dialog.

With this update it's not only possible to use strings as a valid type for the `title` prop but also `PropTypes.element`. In my case I always show the dialog title to users, but also wanted to include an decorative SVG icon, which is an element.

If you find this useful please consider to merge this pull-request.
I already did `npm run lint && npm run build`.

Cheers
Eric