### PR TITLE
Add 'onClose' callback for when dialog is closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ npm install --save react-a11y-dialog
 
 ---
 
+* **Property name**: `onClose`
+* **Type**: function
+* **Mandatory**: false
+* **Default value**: no-op
+* **Description**: A callback function that is called when the dialog is closed.
+
+---
+
 * **Property name**: `closeButtonLabel`
 * **Type**: string
 * **Mandatory**: false

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ class Dialog extends React.Component {
 
   close() {
     this.dialog.hide()
+
+    this.props.onClose()
   }
 
   handleRef(element) {
@@ -95,6 +97,7 @@ class Dialog extends React.Component {
 
 Dialog.defaultProps = {
   role: 'dialog',
+  onClose: () => void 0,
   closeButtonLabel: 'Close this dialog window',
   closeButtonContent: '\u00D7',
   classNames: {},
@@ -128,6 +131,9 @@ Dialog.propTypes = {
   // technologies to provide context and meaning to the dialog window. Falls
   // back to the `${this.props.id}-title` if not provided.
   titleId: PropTypes.string,
+
+  // A callback function that is called when the dialog is closed.
+  onClose: PropTypes.func,
 
   // The HTML `aria-label` attribute of the close button, used by assistive
   // technologies to provide extra meaning to the usual cross-mark. Defaults


### PR DESCRIPTION
Right now, the only way I was able to detect when the dialog has been closed is to listen to the `hide` event fired off by `A11yDialog`.

```js
handleRef = (dialog: Dialog) => {
    this._dialog = dialog;
    this._dialog.on('hide', () => {
        this.props.onDismiss(); // custom component props
    });
};

// ...

render() {
    return (
        <Dialog
            id="my-accessible-dialog"
            appRoot="#main"
            dialogRoot="#dialog-root"
            dialogRef={this.handleRef}
            title="The dialog title"
        >
    );
}
```

This PR adds an `onClose` callback to the `<Dialog>` component that is called whenever the dialog is closed so I can do something like this instead:

```js
<Dialog
    id="my-accessible-dialog"
    appRoot="#main"
    dialogRoot="#dialog-root"
    dialogRef={(dialog) => (this._dialog = dialog)}
    title="The dialog title"
    onClose={this.props.onDismiss}
>
```