### PR TITLE
Adds ability to control button position

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ npm install --save react-a11y-dialog
 - **Type**: string
 - **Mandatory**: false
 - **Default value**: `first`
-- **Description**: Whether to render the close button before/after the heading or not at all. Options are: `first`, `last`, `none`
+- **Description**: Whether to render the close button before/after the heading or not at all. Options are: `first`, `last`, `none`. **⚠️ Caution!** If you set it to `none`, you'll have to implement your own close button inside the dialog.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `id`
 - **Type**: string
-- **Mandatory**: true
+- **Required**: true
 - **Default value**: —
 - **Description**: The HTML `id` attribute of the dialog element, internally used by a11y-dialog to manipulate the dialog.
 
@@ -28,7 +28,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `title`
 - **Type**: string | element
-- **Mandatory**: true
+- **Required**: true
 - **Default value**: —
 - **Description**: The title of the dialog, mandatory in the document to provide context to assistive technology. Could be [hidden with CSS](https://hugogiraudel.com/2016/10/13/css-hide-and-seek/) (while remaining accessible).
 
@@ -36,7 +36,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `dialogRef`
 - **Type**: function
-- **Mandatory**: false
+- **Required**: false
 - **Default value**: no-op
 - **Description**: A function called when the component has mounted, receiving the [instance of A11yDialog](http://edenspiekermann.github.io/a11y-dialog/#js-api) so that it can be programmatically accessed later on.
 
@@ -44,7 +44,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `appRoot`
 - **Type**: string | string[]
-- **Mandatory**: true
+- **Required**: true
 - **Default value**: —
 - **Description**: The [selector(s) a11y-dialog need](http://edenspiekermann.github.io/a11y-dialog/#javascript-instantiation) to disable when the dialog is open.
 
@@ -52,7 +52,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `dialogRoot`
 - **Type**: string
-- **Mandatory**: true
+- **Required**: true
 - **Default value**: —
 - **Description**: The container for the dialog to be rendered into ([React portal](https://reactjs.org/docs/portals.html)’s root).
 
@@ -60,7 +60,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `titleId`
 - **Type**: string
-- **Mandatory**: false
+- **Required**: false
 - **Default value**: `${this.props.id}-title`
 - **Description**: The HTML `id` attribute of the dialog’s title element, used by assistive technologies to provide context and meaning to the dialog window.
 
@@ -68,7 +68,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `closeButtonLabel`
 - **Type**: string
-- **Mandatory**: false
+- **Required**: false
 - **Default value**: “Close this dialog window”
 - **Description**: The HTML `aria-label` attribute of the close button, used by assistive technologies to provide extra meaning to the usual cross-mark.
 
@@ -76,7 +76,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `closeButtonContent`
 - **Type**: string | element
-- **Mandatory**: false
+- **Required**: false
 - **Default value**: `\u00D7` (×)
 - **Description**: The string that is the inner HTML of the close button.
 
@@ -84,15 +84,15 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `closeButtonPosition`
 - **Type**: string
-- **Mandatory**: false
+- **Required**: false
 - **Default value**: `first`
-- **Description**: Whether to render the close button before/after the heading or not at all. Options are: `first`, `last`, `none`. **⚠️ Caution!** If you set it to `none`, you'll have to implement your own close button inside the dialog.
+- **Description**: Whether to render the close button as first element, last element or not at all. Options are: `first`, `last` and `none`. ⚠️ **Caution!** Setting it to `none` without providing a close button manually will be a critical accessibility issue.
 
 ---
 
 - **Property name**: `classNames`
 - **Type**: object
-- **Mandatory**: false
+- **Required**: false
 - **Default value**: {}
 - **Description**: Object of classes for each HTML element of the dialog element. Keys are: `base`, `overlay`, `element`, `document`, `title`, `closeButton`. See [a11y-dialog docs](http://edenspiekermann.github.io/a11y-dialog/#expected-dom-structure) for reference.
 
@@ -100,7 +100,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `useDialog`
 - **Type**: boolean
-- **Mandatory**: false
+- **Required**: false
 - **Default value**: `true`
 - **Description**: Whether to render a `<dialog>` element or a `<div>` element.
 
@@ -108,7 +108,7 @@ npm install --save react-a11y-dialog
 
 - **Property name**: `role`
 - **Type**: string
-- **Mandatory**: false
+- **Required**: false
 - **Default value**: `dialog`
 - **Description**: The `role` attribute of the dialog element, either `dialog` (default) or `alertdialog` to make it a modal (preventing closing on click outside of <kbd>ESC</kbd> key).
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ npm install --save react-a11y-dialog
 
 ---
 
+- **Property name**: `closeButtonPosition`
+- **Type**: string
+- **Mandatory**: false
+- **Default value**: `first`
+- **Description**: Whether to render the close button before/after the heading or not at all. Options are: `first`, `last`, `none`
+
+---
+
 - **Property name**: `classNames`
 - **Type**: object
 - **Mandatory**: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,20 +1,5 @@
 "use strict";
 
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
-exports["default"] = void 0;
-
-var _react = _interopRequireDefault(require("react"));
-
-var _reactDom = _interopRequireDefault(require("react-dom"));
-
-var _a11yDialog = _interopRequireDefault(require("a11y-dialog"));
-
-var _propTypes = _interopRequireDefault(require("prop-types"));
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
-
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -27,32 +12,36 @@ function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
+var React = require('react');
+
+var ReactDOM = require('react-dom');
+
+var A11yDialog = require('a11y-dialog');
+
+var PropTypes = require('prop-types');
+
 var useIsMounted = function useIsMounted() {
-  var _React$useState = _react["default"].useState(false),
+  var _React$useState = React.useState(false),
       _React$useState2 = _slicedToArray(_React$useState, 2),
       isMounted = _React$useState2[0],
       setIsMounted = _React$useState2[1];
 
-  _react["default"].useEffect(function () {
+  React.useEffect(function () {
     return setIsMounted(true);
   }, []);
-
   return isMounted;
 };
 
 var useDialogInstance = function useDialogInstance(_ref) {
   var dialogRef = _ref.dialogRef,
       appRoot = _ref.appRoot;
-
-  var instance = _react["default"].useRef(null);
-
-  var container = _react["default"].useCallback(function (node) {
+  var instance = React.useRef(null);
+  var container = React.useCallback(function (node) {
     if (node !== null) {
-      instance.current = new _a11yDialog["default"](node, appRoot);
+      instance.current = new A11yDialog(node, appRoot);
       dialogRef(instance.current);
     }
   }, [dialogRef, appRoot]);
-
   return {
     container: container,
     instance: instance
@@ -67,72 +56,55 @@ var Dialog = function Dialog(props) {
       container = _useDialogInstance.container,
       instance = _useDialogInstance.instance;
 
-  _react["default"].useEffect(function () {
+  React.useEffect(function () {
     var dialogInstance = instance.current;
     return function () {
       if (dialogInstance) dialogInstance.destroy();
       dialogRef(undefined);
     };
   }, [dialogRef, instance]);
-
-  var close = _react["default"].useCallback(function () {
+  var close = React.useCallback(function () {
     return instance.current.hide();
   }, [instance]);
-
   if (!isMounted) return null;
   var id = props.id,
       classNames = props.classNames;
   var titleId = props.titleId || id + '-title';
   var Element = props.useDialog ? 'dialog' : 'div';
-
-  var CloseButton = function CloseButton() {
-    if (props.closeButtonPosition === 'none') return null;
-    return /*#__PURE__*/_react["default"].createElement("button", {
-      type: "button",
-      "aria-label": props.closeButtonLabel,
-      onClick: close,
-      className: classNames.closeButton
-    }, props.closeButtonContent);
-  };
-
-  var Heading = function Heading() {
-    /**
-     * Using a paragraph with accessibility mapping to work around SEO
-     * concerns of having multiple <h1> per page.
-     * See: https://twitter.com/goetsu/status/1261253532315004930
-     */
-    return /*#__PURE__*/_react["default"].createElement("p", {
-      id: titleId,
-      className: classNames.title,
-      role: "heading",
-      "aria-level": "1"
-    }, props.title);
-  };
-
-  var getChildOrder = function getChildOrder() {
-    if (props.closeButtonPosition === 'first') {
-      return /*#__PURE__*/_react["default"].createElement(_react["default"].Fragment, null, /*#__PURE__*/_react["default"].createElement(CloseButton, null), /*#__PURE__*/_react["default"].createElement(Heading, null));
-    } else if (props.closeButtonPosition === 'last') {
-      return /*#__PURE__*/_react["default"].createElement(_react["default"].Fragment, null, /*#__PURE__*/_react["default"].createElement(Heading, null), /*#__PURE__*/_react["default"].createElement(CloseButton, null));
-    }
-  };
-
-  return /*#__PURE__*/_reactDom["default"].createPortal( /*#__PURE__*/_react["default"].createElement("div", {
+  var title =
+  /*#__PURE__*/
+  // Using a paragraph with accessibility mapping to work around SEO
+  // concerns of having multiple <h1> per page.
+  // See: https://twitter.com/goetsu/status/1261253532315004930
+  React.createElement("p", {
+    role: "heading",
+    "aria-level": "1",
+    id: titleId,
+    className: classNames.title
+  }, props.title);
+  var button = /*#__PURE__*/React.createElement("button", {
+    type: "button",
+    onClick: close,
+    className: classNames.closeButton,
+    "aria-label": props.closeButtonLabel
+  }, props.closeButtonContent);
+  var children = [props.closeButtonPosition === 'first' && button, title, props.children, props.closeButtonPosition === 'last' && button].filter(Boolean);
+  return ReactDOM.createPortal( /*#__PURE__*/React.createElement("div", {
     id: id,
     className: classNames.base,
     ref: container
-  }, /*#__PURE__*/_react["default"].createElement("div", {
+  }, /*#__PURE__*/React.createElement("div", {
     tabIndex: "-1",
     className: classNames.overlay,
     onClick: props.role === 'alertdialog' ? undefined : close
-  }), /*#__PURE__*/_react["default"].createElement(Element, {
+  }), /*#__PURE__*/React.createElement(Element, {
     role: props.role,
     className: classNames.element,
     "aria-labelledby": titleId
-  }, /*#__PURE__*/_react["default"].createElement("div", {
-    role: props.useDialog ? undefined : 'document',
+  }, /*#__PURE__*/React.createElement("div", {
+    role: props.useDialogElement ? undefined : 'document',
     className: classNames.document
-  }, getChildOrder(), props.children))), document.querySelector(props.dialogRoot));
+  }, children))), document.querySelector(props.dialogRoot));
 };
 
 Dialog.defaultProps = {
@@ -152,38 +124,38 @@ Dialog.propTypes = {
   // The `role` attribute of the dialog element, either `dialog` (default) or
   // `alertdialog` to make it a modal (preventing closing on click outside of
   // ESC key).
-  role: _propTypes["default"].oneOf(['dialog', 'alertdialog']),
+  role: PropTypes.oneOf(['dialog', 'alertdialog']),
   // The HTML `id` attribute of the dialog element, internally used by
   // a11y-dialog to manipulate the dialog.
-  id: _propTypes["default"].string.isRequired,
+  id: PropTypes.string.isRequired,
   // The title of the dialog, mandatory in the document to provide context to
   // assistive technology. Could be hidden (while remaining accessible) with
   // CSS though.
-  title: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].element]).isRequired,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   // A function called when the component has mounted, receiving the instance
   // of A11yDialog so that it can be programmatically accessed later on.
   // E.g.: dialogRef={(dialog) => (this.dialog = dialog)}
-  dialogRef: _propTypes["default"].func,
+  dialogRef: PropTypes.func,
   // The HTML `id` attribute of the dialog’s title element, used by assistive
   // technologies to provide context and meaning to the dialog window. Falls
   // back to the `${this.props.id}-title` if not provided.
-  titleId: _propTypes["default"].string,
+  titleId: PropTypes.string,
   // The HTML `aria-label` attribute of the close button, used by assistive
   // technologies to provide extra meaning to the usual cross-mark. Defaults
   // to a generic English explanation.
-  closeButtonLabel: _propTypes["default"].string,
+  closeButtonLabel: PropTypes.string,
   // The string that is the innerHTML of the close button.
-  closeButtonContent: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].element]),
+  closeButtonContent: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   // Whether the close button should be rendered as first/last children or not at all.
-  closeButtonPosition: _propTypes["default"].oneOf(['first', 'last', 'none']),
+  closeButtonPosition: PropTypes.oneOf(['first', 'last', 'none']),
   // a11y-dialog needs one or more “targets” to disable when the dialog is open.
   // This prop can be one or more selector which will be passed to a11y-dialog
   // constructor.
-  appRoot: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].arrayOf(_propTypes["default"].string)]).isRequired,
+  appRoot: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]).isRequired,
   // React 16 requires a container for the portal’s content to be rendered
   // into; this is required and needs to be an existing valid DOM node,
   // adjacent to the React root container of the application.
-  dialogRoot: _propTypes["default"].string.isRequired,
+  dialogRoot: PropTypes.string.isRequired,
   // Object of classes for each HTML element of the dialog element. Keys are:
   // - base
   // - overlay
@@ -192,13 +164,12 @@ Dialog.propTypes = {
   // - title
   // - closeButton
   // See for reference: http://edenspiekermann.github.io/a11y-dialog/#expected-dom-structure
-  classNames: _propTypes["default"].objectOf(_propTypes["default"].string),
+  classNames: PropTypes.objectOf(PropTypes.string),
   // Whether to render a `<dialog>` element or a `<div>` element.
-  useDialog: _propTypes["default"].bool,
+  useDialogElement: PropTypes.bool,
   // Dialog content.
   // Anything that can be rendered: numbers, strings, elements or an array
   // (or fragment) containing these types.
-  children: _propTypes["default"].node
+  children: PropTypes.node
 };
-var _default = Dialog;
-exports["default"] = _default;
+module.exports = Dialog;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,5 +1,20 @@
 "use strict";
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _reactDom = _interopRequireDefault(require("react-dom"));
+
+var _a11yDialog = _interopRequireDefault(require("a11y-dialog"));
+
+var _propTypes = _interopRequireDefault(require("prop-types"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -12,83 +27,119 @@ function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(
 
 function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
-var React = require('react');
-
-var ReactDOM = require('react-dom');
-
-var A11yDialog = require('a11y-dialog');
-
-var PropTypes = require('prop-types');
-
 var useIsMounted = function useIsMounted() {
-  var _React$useState = React.useState(false),
+  var _React$useState = _react["default"].useState(false),
       _React$useState2 = _slicedToArray(_React$useState, 2),
       isMounted = _React$useState2[0],
       setIsMounted = _React$useState2[1];
 
-  React.useEffect(function () {
+  _react["default"].useEffect(function () {
     return setIsMounted(true);
   }, []);
+
   return isMounted;
+};
+
+var useDialogInstance = function useDialogInstance(_ref) {
+  var dialogRef = _ref.dialogRef,
+      appRoot = _ref.appRoot;
+
+  var instance = _react["default"].useRef(null);
+
+  var container = _react["default"].useCallback(function (node) {
+    if (node !== null) {
+      instance.current = new _a11yDialog["default"](node, appRoot);
+      dialogRef(instance.current);
+    }
+  }, [dialogRef, appRoot]);
+
+  return {
+    container: container,
+    instance: instance
+  };
 };
 
 var Dialog = function Dialog(props) {
   var isMounted = useIsMounted();
-  var container = React.useRef(null);
-  var instance = React.useRef(null);
-  var dialogRef = props.dialogRef,
-      appRoot = props.appRoot;
-  React.useEffect(function () {
-    if (container.current) {
-      instance.current = new A11yDialog(container.current, appRoot);
-      dialogRef(instance.current);
-    }
+  var dialogRef = props.dialogRef;
 
+  var _useDialogInstance = useDialogInstance(props),
+      container = _useDialogInstance.container,
+      instance = _useDialogInstance.instance;
+
+  _react["default"].useEffect(function () {
+    var dialogInstance = instance.current;
     return function () {
-      if (instance.current) instance.current.destroy();
+      if (dialogInstance) dialogInstance.destroy();
       dialogRef(undefined);
     };
-  }, [container, dialogRef, appRoot]);
-  var close = React.useCallback(function () {
+  }, [dialogRef, instance]);
+
+  var close = _react["default"].useCallback(function () {
     return instance.current.hide();
-  }, []);
+  }, [instance]);
+
   if (!isMounted) return null;
   var id = props.id,
       classNames = props.classNames;
   var titleId = props.titleId || id + '-title';
   var Element = props.useDialog ? 'dialog' : 'div';
-  return ReactDOM.createPortal( /*#__PURE__*/React.createElement("div", {
+
+  var CloseButton = function CloseButton() {
+    if (props.closeButtonPosition === 'none') return null;
+    return /*#__PURE__*/_react["default"].createElement("button", {
+      type: "button",
+      "aria-label": props.closeButtonLabel,
+      onClick: close,
+      className: classNames.closeButton
+    }, props.closeButtonContent);
+  };
+
+  var Heading = function Heading() {
+    /**
+     * Using a paragraph with accessibility mapping to work around SEO
+     * concerns of having multiple <h1> per page.
+     * See: https://twitter.com/goetsu/status/1261253532315004930
+     */
+    return /*#__PURE__*/_react["default"].createElement("p", {
+      id: titleId,
+      className: classNames.title,
+      role: "heading",
+      "aria-level": "1"
+    }, props.title);
+  };
+
+  var getChildOrder = function getChildOrder() {
+    if (props.closeButtonPosition === 'first') {
+      return /*#__PURE__*/_react["default"].createElement(_react["default"].Fragment, null, /*#__PURE__*/_react["default"].createElement(CloseButton, null), /*#__PURE__*/_react["default"].createElement(Heading, null));
+    } else if (props.closeButtonPosition === 'last') {
+      return /*#__PURE__*/_react["default"].createElement(_react["default"].Fragment, null, /*#__PURE__*/_react["default"].createElement(Heading, null), /*#__PURE__*/_react["default"].createElement(CloseButton, null));
+    }
+  };
+
+  return /*#__PURE__*/_reactDom["default"].createPortal( /*#__PURE__*/_react["default"].createElement("div", {
     id: id,
     className: classNames.base,
     ref: container
-  }, /*#__PURE__*/React.createElement("div", {
+  }, /*#__PURE__*/_react["default"].createElement("div", {
     tabIndex: "-1",
     className: classNames.overlay,
     onClick: props.role === 'alertdialog' ? undefined : close
-  }), /*#__PURE__*/React.createElement(Element, {
+  }), /*#__PURE__*/_react["default"].createElement(Element, {
     role: props.role,
     className: classNames.element,
     "aria-labelledby": titleId
-  }, /*#__PURE__*/React.createElement("div", {
+  }, /*#__PURE__*/_react["default"].createElement("div", {
     role: props.useDialog ? undefined : 'document',
     className: classNames.document
-  }, /*#__PURE__*/React.createElement("button", {
-    type: "button",
-    "aria-label": props.closeButtonLabel,
-    onClick: close,
-    className: classNames.closeButton
-  }, props.closeButtonContent), /*#__PURE__*/React.createElement("p", {
-    id: titleId,
-    className: classNames.title,
-    role: "heading",
-    "aria-level": "1"
-  }, props.title), props.children))), document.querySelector(props.dialogRoot));
+  }, getChildOrder(), props.children))), document.querySelector(props.dialogRoot));
 };
 
 Dialog.defaultProps = {
   role: 'dialog',
   closeButtonLabel: 'Close this dialog window',
   closeButtonContent: "\xD7",
+  closeButtonPosition: 'first',
   classNames: {},
   dialogRef: function dialogRef() {
     return void 0;
@@ -101,36 +152,38 @@ Dialog.propTypes = {
   // The `role` attribute of the dialog element, either `dialog` (default) or
   // `alertdialog` to make it a modal (preventing closing on click outside of
   // ESC key).
-  role: PropTypes.oneOf(['dialog', 'alertdialog']),
+  role: _propTypes["default"].oneOf(['dialog', 'alertdialog']),
   // The HTML `id` attribute of the dialog element, internally used by
   // a11y-dialog to manipulate the dialog.
-  id: PropTypes.string.isRequired,
+  id: _propTypes["default"].string.isRequired,
   // The title of the dialog, mandatory in the document to provide context to
   // assistive technology. Could be hidden (while remaining accessible) with
   // CSS though.
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  title: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].element]).isRequired,
   // A function called when the component has mounted, receiving the instance
   // of A11yDialog so that it can be programmatically accessed later on.
   // E.g.: dialogRef={(dialog) => (this.dialog = dialog)}
-  dialogRef: PropTypes.func,
+  dialogRef: _propTypes["default"].func,
   // The HTML `id` attribute of the dialog’s title element, used by assistive
   // technologies to provide context and meaning to the dialog window. Falls
   // back to the `${this.props.id}-title` if not provided.
-  titleId: PropTypes.string,
+  titleId: _propTypes["default"].string,
   // The HTML `aria-label` attribute of the close button, used by assistive
   // technologies to provide extra meaning to the usual cross-mark. Defaults
   // to a generic English explanation.
-  closeButtonLabel: PropTypes.string,
+  closeButtonLabel: _propTypes["default"].string,
   // The string that is the innerHTML of the close button.
-  closeButtonContent: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  closeButtonContent: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].element]),
+  // Whether the close button should be rendered as first/last children or not at all.
+  closeButtonPosition: _propTypes["default"].oneOf(['first', 'last', 'none']),
   // a11y-dialog needs one or more “targets” to disable when the dialog is open.
   // This prop can be one or more selector which will be passed to a11y-dialog
   // constructor.
-  appRoot: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]).isRequired,
+  appRoot: _propTypes["default"].oneOfType([_propTypes["default"].string, _propTypes["default"].arrayOf(_propTypes["default"].string)]).isRequired,
   // React 16 requires a container for the portal’s content to be rendered
   // into; this is required and needs to be an existing valid DOM node,
   // adjacent to the React root container of the application.
-  dialogRoot: PropTypes.string.isRequired,
+  dialogRoot: _propTypes["default"].string.isRequired,
   // Object of classes for each HTML element of the dialog element. Keys are:
   // - base
   // - overlay
@@ -139,12 +192,13 @@ Dialog.propTypes = {
   // - title
   // - closeButton
   // See for reference: http://edenspiekermann.github.io/a11y-dialog/#expected-dom-structure
-  classNames: PropTypes.objectOf(PropTypes.string),
+  classNames: _propTypes["default"].objectOf(_propTypes["default"].string),
   // Whether to render a `<dialog>` element or a `<div>` element.
-  useDialog: PropTypes.bool,
+  useDialog: _propTypes["default"].bool,
   // Dialog content.
   // Anything that can be rendered: numbers, strings, elements or an array
   // (or fragment) containing these types.
-  children: PropTypes.node
+  children: _propTypes["default"].node
 };
-module.exports = Dialog;
+var _default = Dialog;
+exports["default"] = _default;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,37 @@ const useDialogInstance = ({ dialogRef, appRoot }) => {
   return { container, instance }
 }
 
+const CloseButton = props => {
+  return (
+    <button
+      type='button'
+      aria-label={props.closeButtonLabel}
+      onClick={props.onClose}
+      className={props.classNames.closeButton}
+    >
+      {props.closeButtonContent}
+    </button>
+  )
+}
+
+const Heading = props => {
+  /**
+   * Using a paragraph with accessibility mapping to work around SEO
+   * concerns of having multiple <h1> per page.
+   * See: https://twitter.com/goetsu/status/1261253532315004930
+   */
+  return (
+    <p
+      id={props.titleId}
+      className={props.classNames.title}
+      role='heading'
+      aria-level='1'
+    >
+      {props.title}
+    </p>
+  )
+}
+
 const Dialog = props => {
   const isMounted = useIsMounted()
   const { dialogRef } = props
@@ -47,52 +78,30 @@ const Dialog = props => {
   const { id, classNames } = props
   const titleId = props.titleId || id + '-title'
   const Element = props.useDialog ? 'dialog' : 'div'
-  const CloseButton = () => {
-    return (
-      <button
-        type='button'
-        aria-label={props.closeButtonLabel}
-        onClick={close}
-        className={classNames.closeButton}
-      >
-        {props.closeButtonContent}
-      </button>
-    )
-  }
-  const Heading = () => {
-    /**
-     * Using a paragraph with accessibility mapping to work around SEO
-     * concerns of having multiple <h1> per page.
-     * See: https://twitter.com/goetsu/status/1261253532315004930
-     */
-    return (
-      <p
-        id={titleId}
-        className={classNames.title}
-        role='heading'
-        aria-level='1'
-      >
-        {props.title}
-      </p>
-    )
-  }
   const getChildOrder = () => {
     if (props.closeButtonPosition === 'first') {
       return (
         <React.Fragment>
-          <CloseButton />
-          <Heading />
+          <CloseButton onClose={close} {...props} />
+          <Heading titleId={titleId} {...props} />
+          {props.children}
         </React.Fragment>
       )
     } else if (props.closeButtonPosition === 'last') {
       return (
         <React.Fragment>
-          <Heading />
-          <CloseButton />
+          <Heading titleId={titleId} {...props} />
+          {props.children}
+          <CloseButton onClose={close} {...props} />
         </React.Fragment>
       )
     } else if (props.closeButtonPosition === 'none') {
-      return <Heading />
+      return (
+        <React.Fragment>
+          <Heading titleId={titleId} {...props} />
+          {props.children}
+        </React.Fragment>
+      )
     }
   }
 
@@ -114,7 +123,6 @@ const Dialog = props => {
           className={classNames.document}
         >
           {getChildOrder()}
-          {props.children}
         </div>
       </Element>
     </div>,
@@ -205,4 +213,4 @@ Dialog.propTypes = {
   children: PropTypes.node,
 }
 
-export default Dialog
+module.exports = Dialog

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import A11yDialog from 'a11y-dialog'
-import PropTypes from 'prop-types'
+const React = require('react')
+const ReactDOM = require('react-dom')
+const A11yDialog = require('a11y-dialog')
+const PropTypes = require('prop-types')
 
 const useIsMounted = () => {
   const [isMounted, setIsMounted] = React.useState(false)

--- a/index.js
+++ b/index.js
@@ -26,37 +26,6 @@ const useDialogInstance = ({ dialogRef, appRoot }) => {
   return { container, instance }
 }
 
-const CloseButton = props => {
-  return (
-    <button
-      type='button'
-      aria-label={props.closeButtonLabel}
-      onClick={props.onClose}
-      className={props.classNames.closeButton}
-    >
-      {props.closeButtonContent}
-    </button>
-  )
-}
-
-const Heading = props => {
-  /**
-   * Using a paragraph with accessibility mapping to work around SEO
-   * concerns of having multiple <h1> per page.
-   * See: https://twitter.com/goetsu/status/1261253532315004930
-   */
-  return (
-    <p
-      id={props.titleId}
-      className={props.classNames.title}
-      role='heading'
-      aria-level='1'
-    >
-      {props.title}
-    </p>
-  )
-}
-
 const Dialog = props => {
   const isMounted = useIsMounted()
   const { dialogRef } = props
@@ -78,32 +47,30 @@ const Dialog = props => {
   const { id, classNames } = props
   const titleId = props.titleId || id + '-title'
   const Element = props.useDialog ? 'dialog' : 'div'
-  const getChildOrder = () => {
-    if (props.closeButtonPosition === 'first') {
-      return (
-        <React.Fragment>
-          <CloseButton onClose={close} {...props} />
-          <Heading titleId={titleId} {...props} />
-          {props.children}
-        </React.Fragment>
-      )
-    } else if (props.closeButtonPosition === 'last') {
-      return (
-        <React.Fragment>
-          <Heading titleId={titleId} {...props} />
-          {props.children}
-          <CloseButton onClose={close} {...props} />
-        </React.Fragment>
-      )
-    } else if (props.closeButtonPosition === 'none') {
-      return (
-        <React.Fragment>
-          <Heading titleId={titleId} {...props} />
-          {props.children}
-        </React.Fragment>
-      )
-    }
-  }
+  const title = (
+    // Using a paragraph with accessibility mapping to work around SEO
+    // concerns of having multiple <h1> per page.
+    // See: https://twitter.com/goetsu/status/1261253532315004930
+    <p role='heading' aria-level='1' id={titleId} className={classNames.title}>
+      {props.title}
+    </p>
+  )
+  const button = (
+    <button
+      type='button'
+      onClick={close}
+      className={classNames.closeButton}
+      aria-label={props.closeButtonLabel}
+    >
+      {props.closeButtonContent}
+    </button>
+  )
+  const children = [
+    props.closeButtonPosition === 'first' && button,
+    title,
+    props.children,
+    props.closeButtonPosition === 'last' && button,
+  ].filter(Boolean)
 
   return ReactDOM.createPortal(
     <div id={id} className={classNames.base} ref={container}>
@@ -122,7 +89,7 @@ const Dialog = props => {
           role={props.useDialogElement ? undefined : 'document'}
           className={classNames.document}
         >
-          {getChildOrder()}
+          {children}
         </div>
       </Element>
     </div>,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-const React = require('react')
-const ReactDOM = require('react-dom')
-const A11yDialog = require('a11y-dialog')
-const PropTypes = require('prop-types')
+import React from 'react'
+import ReactDOM from 'react-dom'
+import A11yDialog from 'a11y-dialog'
+import PropTypes from 'prop-types'
 
 const useIsMounted = () => {
   const [isMounted, setIsMounted] = React.useState(false)
@@ -47,6 +47,54 @@ const Dialog = props => {
   const { id, classNames } = props
   const titleId = props.titleId || id + '-title'
   const Element = props.useDialog ? 'dialog' : 'div'
+  const CloseButton = () => {
+    return (
+      <button
+        type='button'
+        aria-label={props.closeButtonLabel}
+        onClick={close}
+        className={classNames.closeButton}
+      >
+        {props.closeButtonContent}
+      </button>
+    )
+  }
+  const Heading = () => {
+    /**
+     * Using a paragraph with accessibility mapping to work around SEO
+     * concerns of having multiple <h1> per page.
+     * See: https://twitter.com/goetsu/status/1261253532315004930
+     */
+    return (
+      <p
+        id={titleId}
+        className={classNames.title}
+        role='heading'
+        aria-level='1'
+      >
+        {props.title}
+      </p>
+    )
+  }
+  const getChildOrder = () => {
+    if (props.closeButtonPosition === 'first') {
+      return (
+        <React.Fragment>
+          <CloseButton />
+          <Heading />
+        </React.Fragment>
+      )
+    } else if (props.closeButtonPosition === 'last') {
+      return (
+        <React.Fragment>
+          <Heading />
+          <CloseButton />
+        </React.Fragment>
+      )
+    } else if (props.closeButtonPosition === 'none') {
+      return <Heading />
+    }
+  }
 
   return ReactDOM.createPortal(
     <div id={id} className={classNames.base} ref={container}>
@@ -65,29 +113,7 @@ const Dialog = props => {
           role={props.useDialog ? undefined : 'document'}
           className={classNames.document}
         >
-          <button
-            type='button'
-            aria-label={props.closeButtonLabel}
-            onClick={close}
-            className={classNames.closeButton}
-          >
-            {props.closeButtonContent}
-          </button>
-
-          {/**
-           * Using a paragraph with accessibility mapping to work around SEO
-           * concerns of having multiple <h1> per page.
-           * See: https://twitter.com/goetsu/status/1261253532315004930
-           */}
-          <p
-            id={titleId}
-            className={classNames.title}
-            role='heading'
-            aria-level='1'
-          >
-            {props.title}
-          </p>
-
+          {getChildOrder()}
           {props.children}
         </div>
       </Element>
@@ -100,6 +126,7 @@ Dialog.defaultProps = {
   role: 'dialog',
   closeButtonLabel: 'Close this dialog window',
   closeButtonContent: '\u00D7',
+  closeButtonPosition: 'first',
   classNames: {},
   dialogRef: () => void 0,
   useDialog: true,
@@ -143,6 +170,9 @@ Dialog.propTypes = {
     PropTypes.element,
   ]),
 
+  // Whether the close button should be rendered as first/last children or not at all.
+  closeButtonPosition: PropTypes.oneOf(['first', 'last', 'none']),
+
   // a11y-dialog needs one or more “targets” to disable when the dialog is open.
   // This prop can be one or more selector which will be passed to a11y-dialog
   // constructor.
@@ -175,4 +205,4 @@ Dialog.propTypes = {
   children: PropTypes.node,
 }
 
-module.exports = Dialog
+export default Dialog

--- a/test.js
+++ b/test.js
@@ -163,7 +163,7 @@ describe('The A11yDialog component', () => {
     expect(container).toHaveAttribute('aria-hidden', 'true')
   })
 
-  it('should render close button as first element', () => {
+  it('should render close button as first element by default', () => {
     render(<Test closeButtonContent='×' closeButtonLabel='Close the dialog' />)
 
     const inner = screen.getByRole('dialog', { hidden: true }).firstChild
@@ -172,7 +172,7 @@ describe('The A11yDialog component', () => {
     expect(inner.firstElementChild).toEqual(button)
   })
 
-  it('should render close button as second element', () => {
+  it('should render close button as last element if instructed so', () => {
     render(
       <Test
         closeButtonContent='×'
@@ -189,7 +189,7 @@ describe('The A11yDialog component', () => {
     expect(inner.firstElementChild).not.toEqual(button)
   })
 
-  it('should not render close button', () => {
+  it('should not render close button if instructed so', () => {
     render(<Test closeButtonPosition='none' />)
 
     const button = screen.queryByText('×')

--- a/test.js
+++ b/test.js
@@ -162,4 +162,37 @@ describe('The A11yDialog component', () => {
     fireEvent.click(button)
     expect(container).toHaveAttribute('aria-hidden', 'true')
   })
+
+  it('should render close button as first element', () => {
+    render(<Test closeButtonContent='×' closeButtonLabel='Close the dialog' />)
+
+    const inner = screen.getByRole('dialog', { hidden: true }).firstChild
+    const button = screen.getByText('×')
+
+    expect(inner.firstElementChild).toEqual(button)
+  })
+
+  it('should render close button as second element', () => {
+    render(
+      <Test
+        closeButtonContent='×'
+        closeButtonLabel='Close the dialog'
+        closeButtonPosition='last'
+      />
+    )
+
+    const inner = screen.getByRole('dialog', { hidden: true }).firstChild
+    const button = screen.getByText('×')
+    const title = screen.getByText('Test')
+
+    expect(inner.firstElementChild).toEqual(title)
+    expect(inner.firstElementChild).not.toEqual(button)
+  })
+
+  it('should not render close button', () => {
+    render(<Test closeButtonPosition='none' />)
+
+    const button = screen.queryByText('×')
+    expect(button).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
This adds the property `closeButtonPosition` to control the button rendering position.

- `first`: Close button will be rendered as first child; current behaviour.
- `last`: Close button will be rendered _after_  the heading element (naming might be confusing as one could expect "last" to imply as last child element, _after_ content)
- `none`:  The button will not be rendered at all.